### PR TITLE
Adds references to FacePhi Java libs for WebLogic

### DIFF
--- a/weblogic.xml
+++ b/weblogic.xml
@@ -1,19 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <weblogic-web-app xmlns="http://xmlns.oracle.com/weblogic/weblogic-web-app" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd http://xmlns.oracle.com/weblogic/weblogic-web-app http://xmlns.oracle.com/weblogic/weblogic-web-app/1.2/weblogic-web-app.xsd">
-  <jsp-descriptor>
-    <keepgenerated>true</keepgenerated>
-    <debug>true</debug>
-  </jsp-descriptor>
+    <jsp-descriptor>
+        <keepgenerated>true</keepgenerated>
+        <debug>true</debug>
+    </jsp-descriptor>
 
-  <context-root>/facephi-service</context-root>
-  <servlet-descriptor>
-    <servlet-name>PedestalServlet</servlet-name>
-  </servlet-descriptor>
+    <context-root>/facephi-service</context-root>
+    <servlet-descriptor>
+        <servlet-name>PedestalServlet</servlet-name>
+    </servlet-descriptor>
 
     <container-descriptor>
-    <prefer-application-packages>
-        <package-name>org.joda.time.*</package-name>
-    </prefer-application-packages>
-  </container-descriptor>
+        <prefer-application-packages>
+            <package-name>org.joda.time.*</package-name>
+        </prefer-application-packages>
+    </container-descriptor>
+
+    <library-ref>
+        <library-name>fphi-licensing-java-5</library-name>
+    </library-ref>
+
+    <library-ref>
+        <library-name>fphi-matcher-java-5</library-name>
+    </library-ref>
 
 </weblogic-web-app>


### PR DESCRIPTION
This configuration assumes that the FacePhi Java libs are deployed as
libraries in the WebLogic Application Server.
